### PR TITLE
Define alert as int not bool

### DIFF
--- a/firmware/examples/MAX17043_Simple.cpp
+++ b/firmware/examples/MAX17043_Simple.cpp
@@ -31,7 +31,7 @@ Distributed as-is; no warranty is given.
 
 double voltage = 0; // Variable to keep track of LiPo voltage
 double soc = 0; // Variable to keep track of LiPo state-of-charge (SOC)
-bool alert; // Variable to keep track of whether alert has been triggered
+int alert; // Variable to keep track of whether alert has been triggered
 
 void setup()
 {


### PR DESCRIPTION
Closes #1

To be honest I'm not sure if this is the correct fix, but it successfully flashed for me after making the change.

@jimblom 

Cheers!
